### PR TITLE
Cleanup duplicate JWT empty validation and make consts use all caps i…

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,9 +6,9 @@ export enum Environment {
   PRODUCTION = "production"
 }
 
-const secretRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\!\@\#\$\%\^\&\*\(\)\_\+])[0-9a-zA-Z\!\@\#\$\%\^\&\*\(\)\_\+\/\,\.\<\\\>\{\}\[\]\;\:\`\-\+\=]{64,}$/;
-const ipfsHostRegex = /^http(s)?:\/\/[a-zA-Z0-9\%\.\_\+\~\#\=]{1,256}\:[0-9]{1,5}([a-zA-Z0-9\(\)\@\:\%\_\+\.\~\#\?\&\/\=]*)$/;
-const mongoHostRegex = /^[a-zA-Z0-9\%\.\_\+\~\#\=]{1,256}$/;
+const SECRET_REGEX = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\!\@\#\$\%\^\&\*\(\)\_\+])[0-9a-zA-Z\!\@\#\$\%\^\&\*\(\)\_\+\/\,\.\<\\\>\{\}\[\]\;\:\`\-\+\=]{64,}$/;
+const IPFS_HOST_REGEX = /^http(s)?:\/\/[a-zA-Z0-9\%\.\_\+\~\#\=]{1,256}\:[0-9]{1,5}([a-zA-Z0-9\(\)\@\:\%\_\+\.\~\#\?\&\/\=]*)$/;
+const MONGO_HOST_REGEX = /^[a-zA-Z0-9\%\.\_\+\~\#\=]{1,256}$/;
 
 // Check all environment variables are properly set and valid, exit if not
 export function validateEnvironment() {
@@ -37,9 +37,9 @@ export function validateEnvironment() {
 
     // Verify environment variables
     if (Environment.PRODUCTION === process.env.WESTEGG_ENV) {
-      let regexMatch = process.env.JWT_SECRET?.match(secretRegex) as string[];
+      let regexMatch = process.env.JWT_SECRET?.match(SECRET_REGEX) as string[];
       let matchString = regexMatch?.join("");
-      if (matchString !== process.env.JWT_SECRET || !process.env.JWT_SECRET) {
+      if (matchString !== process.env.JWT_SECRET) {
         throw new Error("JWT secret key not complex enough!");
       }
     }
@@ -52,7 +52,9 @@ export function validateEnvironment() {
       throw new Error("MongoDB protocol missing or malformed!");
     }
 
-    let regexMatch = process.env.MONGO_HOST?.match(mongoHostRegex) as string[];
+    let regexMatch = process.env.MONGO_HOST?.match(
+      MONGO_HOST_REGEX
+    ) as string[];
     let matchString = regexMatch?.join("");
     if (!process.env.MONGO_HOST || matchString !== process.env.MONGO_HOST) {
       throw new Error("MongoDB host missing or malformed!");
@@ -63,7 +65,7 @@ export function validateEnvironment() {
     }
 
     if (Environment.DEV === process.env.WESTEGG_ENV) {
-      let regexMatch = process.env.IPFS_URL?.match(ipfsHostRegex) as string[];
+      let regexMatch = process.env.IPFS_URL?.match(IPFS_HOST_REGEX) as string[];
       let matchString = regexMatch?.join("");
       if (matchString !== process.env.IPFS_URL || !process.env.IPFS_URL) {
         throw new Error("IPFS host missing or malformed!");


### PR DESCRIPTION
…n environment variable regex checks

Additions to #40.

@neboman11 I Probably should have seen this in the PR, but the consts should use `CONST_NAME_SCHEME` conventions. Also cleaned up what we talked about with the missing JWT check.