### PR TITLE
feature: Add channel content routes to populate channel modal (#123)

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -4,6 +4,7 @@ MONGO_URL=mongodb://gatsby:gatsby@mongo/gatsby
 GATSBY_URL=http://gatsby:3000/
 MONGO_API_USER=gatsby
 MONGO_API_PASS=gatsby
+NODE_ENV=development
 
 # Gatsby
-WESTEGG_URL=http://localhost:3001
+WESTEGG_URL=http://westegg:3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - gatsby
     env_file:
       - .env
+      - .env.docker
 
   westegg:
     build: .

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/bcrypt": "^3.0.0",
     "@types/busboy": "^0.2.3",
     "@types/express": "^4.17.8",
+    "@types/express-serve-static-core": "^4.17.24",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^16.4.10",
     "@types/validator": "^13.1.0",

--- a/packages/types/lib/requests.ts
+++ b/packages/types/lib/requests.ts
@@ -144,12 +144,14 @@ export type GetUserPromotionsRequest = {
 /*
  * GET /user/:id/listing/recommended
  */
-export type GetUserListingRecommendedRequest = { id: UserID } & CursorRequest;
+export type GetUserListingRecommendedRequest = { id: UserID };
+export type GetUserListingRecommendedRequestQuery = CursorRequest;
 
 /*
  * GET /user/:id/listing/subscriptions
  */
-export type GetUserListingSubscriptionsRequest = { id: UserID } & CursorRequest;
+export type GetUserListingSubscriptionsRequest = { id: UserID };
+export type GetUserListingSubscriptionsRequestQuery = CursorRequest;
 
 /*
  * PUT /user/:id
@@ -341,6 +343,24 @@ export type GetChannelPrivateRequest = {};
 export type GetChannelContentRequest = { id: ChannelID };
 
 /*
+ * GET /channel/:id/videos
+ */
+export type GetChannelVideosRequest = { id: ChannelID };
+export type GetChannelVideosRequestQuery = CursorRequest;
+
+/*
+ * GET /channel/:id/playlists
+ */
+export type GetChannelPlaylistsRequest = { id: ChannelID };
+export type GetChannelPlaylistsRequestQuery = CursorRequest;
+
+/*
+ * GET /channel/:id/shows
+ */
+export type GetChannelShowsRequest = { id: ChannelID };
+export type GetChannelShowsRequestQuery = CursorRequest;
+
+/*
  * PUT /channel/:id
  */
 export type PutChannelRequest = Partial<
@@ -500,7 +520,8 @@ export type GetVideoRequest = { id: string };
 /*
  * GET /video/:id/listing/related
  */
-export type GetVideoListingRelatedRequest = CursorRequest;
+export type GetVideoListingRelatedRequest = {};
+export type GetVideoListingRelatedRequestQuery = CursorRequest;
 
 /*
  * PUT /video/:id
@@ -636,9 +657,11 @@ export type GetListingFeaturedChannelsRequest = {};
 /*
  * GET /listing/videos/popular
  */
-export type GetListingPopularVideosRequest = CursorRequest;
+export type GetListingPopularVideosRequest = {};
+export type GetListingPopularVideosRequestQuery = CursorRequest;
 
 /*
  * GET /listing/videos/new
  */
-export type GetListingNewVideosRequest = CursorRequest;
+export type GetListingNewVideosRequest = {};
+export type GetListingNewVideosRequestQuery = CursorRequest;

--- a/packages/types/lib/responses.ts
+++ b/packages/types/lib/responses.ts
@@ -287,6 +287,21 @@ export type GetChannelPrivateResponse = Response<ChannelPrivateInfo>;
 export type GetChannelContentResponse = Response<ChannelContent>;
 
 /*
+ * GET /channel/:id/videos
+ */
+export type GetChannelVideosResponse = CursorResponse<Array<Video>>;
+
+/*
+ * GET /channel/:id/playlists
+ */
+export type GetChannelPlaylistsResponse = CursorResponse<Array<Playlist>>;
+
+/*
+ * GET /channel/:id/shows
+ */
+export type GetChannelShowsResponse = CursorResponse<Array<Show>>;
+
+/*
  * PUT /channel/:id
  */
 export type PutChannelResponse = Response;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,7 +1714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:^4.17.18":
+"@types/express-serve-static-core@npm:^4.17.18, @types/express-serve-static-core@npm:^4.17.24":
   version: 4.17.24
   resolution: "@types/express-serve-static-core@npm:4.17.24"
   dependencies:
@@ -8303,6 +8303,7 @@ typescript@^4.3.5:
     "@types/bcrypt": ^3.0.0
     "@types/busboy": ^0.2.3
     "@types/express": ^4.17.8
+    "@types/express-serve-static-core": ^4.17.24
     "@types/jsonwebtoken": ^8.5.0
     "@types/node": ^16.4.10
     "@types/validator": ^13.1.0


### PR DESCRIPTION
Closes #123 

There is a lot of code duplication for cursor requests. This will be moved to a middleware or something similar in #140, but is out of scope for this PR.