### PR TITLE
bugfix: Fix nulls returned in cursored responses when reaching end of collection (#151)

### DIFF
--- a/src/routes/channel/index.ts
+++ b/src/routes/channel/index.ts
@@ -226,9 +226,22 @@ router.get(
       .project(projection(keysOf<Video>()))
       .limit(limit)) as Video[];
 
+    // Start pre-alpha demo code block
+    let duplicate = Array(limit - videos.length)
+      .fill(null)
+      .map((item, index) => {
+        return videos[index % videos.length];
+      });
+
+    // Wrap content as single request will have all that's in pre-alpha
+    const nextCursor = CURSOR_START.toString();
+
+    videos = [...videos, ...duplicate];
+    // End pre-alpha demo code block
+
     const response = {
       content: videos,
-      cursor: videos[videos.length - 1]?._id,
+      cursor: nextCursor,
       limit: limit
     };
 

--- a/src/routes/listing/index.ts
+++ b/src/routes/listing/index.ts
@@ -86,16 +86,26 @@ router.get(
       .project(projection(keysOf<Video>()))
       .limit(limit)) as Video[];
 
+    // Start pre-alpha demo code block
     let duplicate = Array(limit - videos.length)
       .fill(null)
       .map((item, index) => {
         return videos[index % videos.length];
       });
+
+    const END_COLLECTION: Types.ObjectId = (
+      await VideoCollection.findOne({}).sort({ $natural: -1 })
+    )?._id;
+
+    // Wrap content as single request will have all that's in pre-alpha
+    const nextCursor = CURSOR_START.toString();
+
     videos = [...videos, ...duplicate];
+    // End pre-alpha demo code block
 
     const response = {
       content: videos,
-      cursor: videos[videos.length - 1]?._id,
+      cursor: nextCursor,
       limit: limit
     };
 
@@ -145,16 +155,22 @@ router.get(
       .project(projection(keysOf<Video>()))
       .limit(limit)) as Video[];
 
+    // Start pre-alpha demo code block
     let duplicate = Array(limit - videos.length)
       .fill(null)
       .map((item, index) => {
         return videos[index % videos.length];
       });
+
+    // Wrap content as single request will have all that's in pre-alpha
+    const nextCursor = CURSOR_START.toString();
+
     videos = [...videos, ...duplicate];
+    // End pre-alpha demo code block
 
     const response = {
       content: videos,
-      cursor: videos[videos.length - 1]?._id,
+      cursor: nextCursor,
       limit: limit
     };
 

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -318,16 +318,22 @@ router.get(
       .project(projection(keysOf<Video>()))
       .limit(limit)) as Video[];
 
+    // Start pre-alpha demo code block
     let duplicate = Array(limit - videos.length)
       .fill(null)
       .map((item, index) => {
         return videos[index % videos.length];
       });
+
+    // Wrap content as single request will have all that's in pre-alpha
+    const nextCursor = CURSOR_START.toString();
+
     videos = [...videos, ...duplicate];
+    // End pre-alpha demo code block
 
     const response = {
       content: videos,
-      cursor: videos[videos.length - 1]?._id,
+      cursor: nextCursor,
       limit: limit
     };
 
@@ -377,16 +383,22 @@ router.get(
       .project(projection(keysOf<Video>()))
       .limit(limit)) as Video[];
 
+    // Start pre-alpha demo code block
     let duplicate = Array(limit - videos.length)
       .fill(null)
       .map((item, index) => {
         return videos[index % videos.length];
       });
+
+    // Wrap content as single request will have all that's in pre-alpha
+    const nextCursor = CURSOR_START.toString();
+
     videos = [...videos, ...duplicate];
+    // End pre-alpha demo code block
 
     const response = {
       content: videos,
-      cursor: videos[videos.length - 1]?._id,
+      cursor: nextCursor,
       limit: limit
     };
 

--- a/src/routes/video/index.ts
+++ b/src/routes/video/index.ts
@@ -208,16 +208,26 @@ router.get(
       .project(projection(keysOf<Video>()))
       .limit(limit)) as Video[];
 
+    // Start pre-alpha demo code block
     let duplicate = Array(limit - videos.length)
       .fill(null)
       .map((item, index) => {
         return videos[index % videos.length];
       });
+
+    const END_COLLECTION: Types.ObjectId = (
+      await VideoCollection.findOne({}).sort({ $natural: -1 })
+    )?._id;
+
+    // Wrap content as single request will have all that's in pre-alpha
+    const nextCursor = CURSOR_START.toString();
+
     videos = [...videos, ...duplicate];
+    // End pre-alpha demo code block
 
     const response = {
       content: videos,
-      cursor: videos[videos.length - 1]?._id,
+      cursor: nextCursor,
       limit: limit
     };
 


### PR DESCRIPTION
Closes #151